### PR TITLE
feature: add history to request response

### DIFF
--- a/dotextensions/server/handlers/basic_handlers.py
+++ b/dotextensions/server/handlers/basic_handlers.py
@@ -108,15 +108,14 @@ class RunHttpFileHandler(BaseHandler):
         body = resp.text
         response_data = {
             "response": {
-                "headers":
-                    {key: value for key, value in resp.headers.items()},
                 "body": body,  # for binary out, it will fail, check for alternatives
-                "status": resp.status_code,
-                "method": resp.request.method,
                 "output_file": output or "",
-                "url": resp.url},
+                **self._get_resp_data(resp)
+            },
             "script_result": script_result,
         }
+        if resp.history:
+            response_data["history"] = [self._get_resp_data(hist_item) for hist_item in resp.history]
         # will be used for response
         data = {}
         data.update(response_data['response'])  # deprecated
@@ -132,6 +131,14 @@ class RunHttpFileHandler(BaseHandler):
         result = Result(id=command.id,
                         result=data)
         return result
+
+    def _get_resp_data(self, resp):
+        return {
+            "headers": {key: value for key, value in resp.headers.items()},
+            "status": resp.status_code,
+            "method": resp.request.method,
+            "url": resp.url
+        }
 
     def get_request_comp(self, config):
         return RequestCompiler(config)

--- a/dothttp/request_base.py
+++ b/dothttp/request_base.py
@@ -390,7 +390,6 @@ class RequestCompiler(RequestBase):
         script_execution = execution_cls(self.httpdef, self.property_util)
         script_execution.pre_request_script()
         resp = self.get_response()
-        self.print_req_info(resp.request)
         for hist_resp in resp.history:
             self.print_req_info(hist_resp, '<')
             request_logger.debug(
@@ -447,6 +446,7 @@ class RequestCompiler(RequestBase):
     def get_response(self):
         session = self.get_session()
         request = self.get_request()
+        self.print_req_info(request)
         session.cookies = request._cookies
         if self.httpdef.p12:
             session.mount(request.url,

--- a/test/extensions/test_history.py
+++ b/test/extensions/test_history.py
@@ -1,0 +1,59 @@
+import json
+from typing import Union
+
+from dotextensions.server.handlers.basic_handlers import ContentExecuteHandler
+from dotextensions.server.models import Command
+from test import TestBase
+
+
+class HistoryValidate(TestBase):
+    def setUp(self) -> None:
+        self.execute_handler = ContentExecuteHandler()
+
+
+    def execute_and_result(self, content, target: Union[str, int] = 1, contexts=None, curl=False):
+        return self.execute_handler.run(Command(
+            method=ContentExecuteHandler.name,
+            params={
+                "content": content,
+                "properties": {
+                    "post": "get"
+                },
+                "target": target,
+                "contexts": contexts,
+                "curl": curl
+            },
+            id=1)
+        )
+
+
+    def test_execute_content(self):
+        result = self.execute_and_result("GET https://httpbin.org/status/301")
+        body = json.loads(result.result['body'])
+        self.assertTrue("args" in body)
+        self.assertTrue("headers" in body)
+        self.assertEqual({}, body['args'])
+        self.assertEqual("https://httpbin.org/get", body['url'])
+        self.assertEqual(200, result.result['status'])
+        self.assertTrue("history" in result.result)
+        self.assertEqual(2, len(result.result['history']))
+        self.assertEqual(301, result.result['history'][0]['status'])
+        self.assertEqual("https://httpbin.org/status/301", result.result['history'][0]['url'])
+        self.assertEqual(302, result.result['history'][1]['status'])
+        self.assertEqual("https://httpbin.org/redirect/1", result.result['history'][1]['url'])
+        print(result.result['history'])
+
+    def test_execute_content2(self):
+        result = self.execute_and_result("GET https://httpbin.org/status/302")
+        body = json.loads(result.result['body'])
+        self.assertTrue("args" in body)
+        self.assertTrue("headers" in body)
+        self.assertEqual({}, body['args'])
+        self.assertEqual("https://httpbin.org/get", body['url'])
+        self.assertEqual(200, result.result['status'])
+        self.assertTrue("history" in result.result)
+        self.assertEqual(2, len(result.result['history']))
+        self.assertEqual(302, result.result['history'][0]['status'])
+        self.assertEqual("https://httpbin.org/status/302", result.result['history'][0]['url'])
+        self.assertEqual(302, result.result['history'][1]['status'])
+        self.assertEqual("https://httpbin.org/redirect/1", result.result['history'][1]['url'])


### PR DESCRIPTION
Any new Feature should handle all of below

- http2har (export to all programming languages using httpsnippet or request sharing)
- har2http (swagger3 import, swagger2 import, curl import)
- postman2http (postman3 postman2 import)
- http2postman (export http file to postman request collection)
- http2curl (mirror, to check syntax or most scenarios)

are expected to work by default for any new feature. here is the checklist

- [x] check request executed properly
    - [x] test case