### PR TITLE
#321 Support aws auth session_token

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,58 +1,27 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.236.0/containers/python-3
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
 	"name": "Python 3",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"context": "..",
-		"args": { 
-			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
-			// Append -bullseye or -buster to pin to an OS version.
-			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.13-bullseye",
-			// Options
-			"NODE_VERSION": "lts/*"
-		}
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
+	"features": {
+		// "ghcr.io/devcontainers/features/aws-cli:1": {},
+		// "ghcr.io/devcontainers/features/azure-cli:1": {},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {}
 	},
 
-	// Configure tool-specific properties.
-	"customizations": {
-		// Configure properties specific to VS Code.
-		"vscode": {
-			// Set *default* container specific settings.json values on container create.
-			"settings": { 
-				"python.defaultInterpreterPath": "/usr/local/bin/python",
-				"python.linting.enabled": true,
-				"python.linting.pylintEnabled": true,
-				"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
-				"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
-				"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
-				"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
-				"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
-				"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
-				"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
-				"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
-				"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
-			},
-			
-			// Add the IDs of extensions you want installed when the container is created.
-			"extensions": [
-				"ms-python.python",
-				"ms-python.vscode-pylance",
-				"ShivaPrasanth.dothttp-code"
-			]
-		}
-	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install poetry && poetry install ",
+	"postCreateCommand": "pip3 install poetry --user && poetry install "
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode",
-	"features": {
-		// "docker-in-docker": "latest"
-	}
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
 }

--- a/dotextensions/server/handlers/http2postman.py
+++ b/dotextensions/server/handlers/http2postman.py
@@ -299,6 +299,7 @@ class Http2Postman(RunHttpFileHandler):
                     ),
                     ApikeyElement(key="region", value=auth.region, type="string"),
                     ApikeyElement(key="service", value=auth.service, type="string"),
+                    ApikeyElement(key="session_token", value=auth.session_token, type="string"),
                 ]
         if http.headers:
             request.header = list(

--- a/dotextensions/server/handlers/postman2http.py
+++ b/dotextensions/server/handlers/postman2http.py
@@ -344,12 +344,14 @@ class ImportPostmanCollection(BaseHandler):
                 secretKey = aws_auth.get("secretKey")
                 region = aws_auth.get("region", "us-east-1")
                 service = aws_auth.get("service", "")
+                session_token = aws_auth.get("session_token", "")
                 auth_wrap = AuthWrap(
                     aws_auth=AwsAuthWrap(
                         access_id=accessKey,
                         secret_token=secretKey,
                         region=region,
                         service=service,
+                        session_token=session_token
                     )
                 )
         return auth_wrap, lines

--- a/dothttp/http.tx
+++ b/dothttp/http.tx
@@ -83,6 +83,7 @@ BASICAUTH:
 AWSAUTH:
     'awsauth' '(' ('access_id' '=' ) ? access_id=DotString ',' ('secret_key' '=')? secret_token=DotString   ( ',' ('service'  '=')? service=DotString )? ','? ')'
     | 'awsauth' '(' ('access_id' '=' ) ? access_id=DotString ',' ('secret_key' '=')? secret_token=DotString ','  ('service'  '=')? service=DotString (',' ('region' '=')? region=DotString)? ')'
+    | 'awsauth' '(' ('access_id' '=' ) ? access_id=DotString ',' ('secret_key' '=')? secret_token=DotString ','  ('service'  '=')? service=DotString ',' ('region' '=')? region=DotString ',' ('session_token' '=') ?  session_token=DotString ')'
 ;
 
 AZUREAUTH:

--- a/dothttp/models/computed.py
+++ b/dothttp/models/computed.py
@@ -282,6 +282,7 @@ class HttpDef:
                         aws_auth.signing_key.secret_key,
                         aws_auth.service,
                         aws_auth.region,
+                        aws_auth.session_token
                     )
                 )
             elif isinstance(self.auth, AzureAuth):

--- a/dothttp/models/parse_models.py
+++ b/dothttp/models/parse_models.py
@@ -41,8 +41,9 @@ class HawkAuth:
 class AwsAuthWrap:
     access_id: str
     secret_token: str
-    service: str
+    service: Union[str, None]
     region: Union[str, None]
+    session_token: Union[str, None]
 
 
 @dataclass

--- a/dothttp/parse/__init__.py
+++ b/dothttp/parse/__init__.py
@@ -679,12 +679,15 @@ class HttpDefBase(BaseModelProcessor):
             elif aws_auth_wrap := auth_wrap.aws_auth:
                 access_id = self.get_updated_content(aws_auth_wrap.access_id)
                 secret_token = self.get_updated_content(aws_auth_wrap.secret_token)
+                session_token = None
                 aws_service = None
                 aws_region = None
                 if aws_auth_wrap.service:
                     aws_service = self.get_updated_content(aws_auth_wrap.service)
                 if aws_auth_wrap.region:
                     aws_region = self.get_updated_content(aws_auth_wrap.region)
+                if aws_auth_wrap.session_token:
+                    session_token = self.get_updated_content(aws_auth_wrap.session_token)
                 parsed_url = urlparse(self.httpdef.url)
                 hostname = parsed_url.hostname
                 if hostname.endswith(".amazonaws.com"):
@@ -780,7 +783,7 @@ class HttpDefBase(BaseModelProcessor):
                         f"aws request with region aws_service: {aws_service} region: {aws_region}"
                     )
                     self.httpdef.auth = AWS4Auth(
-                        access_id, secret_token, aws_region, aws_service
+                        access_id, secret_token, aws_region, aws_service, session_token = session_token
                     )
                 else:
                     # aws service and region can be extracted from url

--- a/dothttp/parse/request_base.py
+++ b/dothttp/parse/request_base.py
@@ -306,12 +306,13 @@ class HttpFileFormatter(RequestBase):
             elif aws_auth := auth_wrap.aws_auth:
                 aws_auth_str =f'{new_line}awsauth(access_id="{aws_auth.access_id}", secret_key="{aws_auth.secret_token}"'
                 if aws_auth.service:
-                    aws_auth_str += f", service={aws_auth.service}"
+                    aws_auth_str += f', service="{aws_auth.service}"'
                 if aws_auth.region:
-                    aws_auth_str += f", region={aws_auth.region}"
+                    aws_auth_str += f', region="{aws_auth.region}"'
                 if aws_auth.session_token:
-                    aws_auth_str += f", session_token={aws_auth.session_token}"
-                aws_auth_str += ")"
+                    aws_auth_str += f', session_token="{aws_auth.session_token}"'
+                aws_auth_str += ')'
+                output_str += aws_auth_str
             elif azure_auth := auth_wrap.azure_auth:
                 if sp_auth := azure_auth.azure_spsecret_auth:
                     output_str += f'{new_line}azurespsecret(tenant_id="{sp_auth.tenant_id}", client_id="{sp_auth.client_id}", client_secret="{sp_auth.client_secret}", scope="{sp_auth.scope}")'

--- a/dothttp/parse/request_base.py
+++ b/dothttp/parse/request_base.py
@@ -304,12 +304,14 @@ class HttpFileFormatter(RequestBase):
             elif hawk_auth := auth_wrap.hawk_auth:
                 output_str += f'{new_line}hawkauth("{hawk_auth.hawk_id}", "{hawk_auth.key}", "{hawk_auth.algorithm}")'
             elif aws_auth := auth_wrap.aws_auth:
-                if aws_auth.service and aws_auth.region:
-                    output_str += f'{new_line}awsauth(access_id="{aws_auth.access_id}", secret_key="{aws_auth.secret_token}", service="{aws_auth.service}", region="{aws_auth.region}")'
-                elif aws_auth.service:
-                    output_str += f'{new_line}awsauth(access_id="{aws_auth.access_id}", secret_key="{aws_auth.secret_token}", service="{aws_auth.service}")'
-                else:
-                    output_str += f'{new_line}awsauth(access_id="{aws_auth.access_id}", secret_key="{aws_auth.secret_token}" )'
+                aws_auth_str =f'{new_line}awsauth(access_id="{aws_auth.access_id}", secret_key="{aws_auth.secret_token}"'
+                if aws_auth.service:
+                    aws_auth_str += f", service={aws_auth.service}"
+                if aws_auth.region:
+                    aws_auth_str += f", region={aws_auth.region}"
+                if aws_auth.session_token:
+                    aws_auth_str += f", session_token={aws_auth.session_token}"
+                aws_auth_str += ")"
             elif azure_auth := auth_wrap.azure_auth:
                 if sp_auth := azure_auth.azure_spsecret_auth:
                     output_str += f'{new_line}azurespsecret(tenant_id="{sp_auth.tenant_id}", client_id="{sp_auth.client_id}", client_secret="{sp_auth.client_secret}", scope="{sp_auth.scope}")'

--- a/test/core/requests/awsauth_format.http
+++ b/test/core/requests/awsauth_format.http
@@ -37,17 +37,17 @@ awsauth(access_id="dummy", secret_key="dummy", service="ec2")
 
 @name("service from url and region defaulted to us-east-1")
 GET "http://s3.amazonaws.com/"
-awsauth(access_id="dummy", secret_key="dummy" )
+awsauth(access_id="dummy", secret_key="dummy")
 
 
 @name("region and service from url with bucket id")
 GET "http://bucketid.s3.us-east-1.amazonaws.com/"
-awsauth(access_id="dummy", secret_key="dummy" )
+awsauth(access_id="dummy", secret_key="dummy")
 
 
 @name("region and service with legacy url")
 GET "http://s3-us-east-1.amazonaws.com/"
-awsauth(access_id="dummy", secret_key="dummy" )
+awsauth(access_id="dummy", secret_key="dummy")
 
 
 @name("fix region and service from url")

--- a/test/extensions/commands/http2postman/awsauth.postman_collection.json
+++ b/test/extensions/commands/http2postman/awsauth.postman_collection.json
@@ -1,732 +1,797 @@
 {
-  "collection": {
-    "auth": null,
+ "collection": {
+  "auth": null,
+  "event": null,
+  "info": {
+   "_postman_id": null,
+   "description": null,
+   "name": "awsauth.http",
+   "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+   "version": null
+  },
+  "item": [
+   {
+    "description": null,
     "event": null,
-    "info": {
-      "_postman_id": null,
-      "description": null,
-      "name": "awsauth.http",
-      "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-      "version": null
-    },
-    "item": [
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "simple",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "us-east-1"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "simple",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.amazonaws.com"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "resolve properties",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "{{access_id}}"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "{{secret_key}}"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "{{region}}"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "resolve properties",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.amazonaws.com"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "resolve properties with default",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "{{access_id=dummy}}"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "{{secret_key=dummy}}"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "{{region=us-east-1}}"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "resolve properties with default",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.amazonaws.com"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "extend",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "{{access_id=dummy}}"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "{{secret_key=dummy}}"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "{{region=us-east-1}}"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "extend",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.amazonaws.com/"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "extend2",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "us-east-1"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "extend2",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.amazonaws.com/some"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "extend3",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "{{access_id}}"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "{{secret_key}}"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "{{region}}"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "extend3",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.amazonaws.com/some2"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "default us-east-1 region optional",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "us-east-1"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "default us-east-1 region optional",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.amazonaws.com/some3"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "region from url and s3",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "eu-west-1"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "region from url and s3",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.eu-west-1.amazonaws.com/some3"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "service from url and region defaulted to us-east-1",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "us-east-1"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "service from url and region defaulted to us-east-1",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.amazonaws.com/"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "region and service from url with bucket id",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "us-east-1"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "region and service from url with bucket id",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://bucketid.s3.us-east-1.amazonaws.com/"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "region and service with legacy url",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "us-east-1"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "region and service with legacy url",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3-us-east-1.amazonaws.com/"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "fix region and service from url",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "us-east-1"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "fix region and service from url",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3-us-east-1.amazonaws.com/"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      },
-      {
-        "description": null,
-        "event": null,
-        "id": null,
-        "name": "fix region and service from url2",
-        "protocolProfileBehavior": null,
-        "request": {
-          "auth": {
-            "apikey": null,
-            "awsv4": [
-              {
-                "key": "accessKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "secretKey",
-                "type": "string",
-                "value": "dummy"
-              },
-              {
-                "key": "region",
-                "type": "string",
-                "value": "us-east-1"
-              },
-              {
-                "key": "service",
-                "type": "string",
-                "value": "s3"
-              }
-            ],
-            "basic": null,
-            "bearer": null,
-            "digest": null,
-            "edgegrid": null,
-            "hawk": null,
-            "noauth": null,
-            "ntlm": null,
-            "oauth1": null,
-            "oauth2": null,
-            "type": "awsv4"
-          },
-          "body": null,
-          "certificate": null,
-          "description": "fix region and service from url2",
-          "header": null,
-          "method": "GET",
-          "proxy": null,
-          "url": "http://s3.us-east-1.amazonaws.com/"
-        },
-        "response": null,
-        "variable": null,
-        "auth": null,
-        "item": null
-      }
-    ],
+    "id": null,
+    "name": "simple",
     "protocolProfileBehavior": null,
-    "variable": null
-  }
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "us-east-1"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "simple",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.amazonaws.com"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "resolve properties",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "{{access_id}}"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "{{secret_key}}"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "{{region}}"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "resolve properties",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.amazonaws.com"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "resolve properties with default",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "{{access_id=dummy}}"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "{{secret_key=dummy}}"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "{{region=us-east-1}}"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "resolve properties with default",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.amazonaws.com"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "extend",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "{{access_id=dummy}}"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "{{secret_key=dummy}}"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "{{region=us-east-1}}"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "extend",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.amazonaws.com/"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "extend2",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "us-east-1"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "extend2",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.amazonaws.com/some"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "extend3",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "{{access_id}}"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "{{secret_key}}"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "{{region}}"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "extend3",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.amazonaws.com/some2"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "default us-east-1 region optional",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "us-east-1"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "default us-east-1 region optional",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.amazonaws.com/some3"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "region from url and s3",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "eu-west-1"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "region from url and s3",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.eu-west-1.amazonaws.com/some3"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "service from url and region defaulted to us-east-1",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "us-east-1"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "service from url and region defaulted to us-east-1",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.amazonaws.com/"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "region and service from url with bucket id",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "us-east-1"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "region and service from url with bucket id",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://bucketid.s3.us-east-1.amazonaws.com/"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "region and service with legacy url",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "us-east-1"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "region and service with legacy url",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3-us-east-1.amazonaws.com/"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "fix region and service from url",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "us-east-1"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "fix region and service from url",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3-us-east-1.amazonaws.com/"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   },
+   {
+    "description": null,
+    "event": null,
+    "id": null,
+    "name": "fix region and service from url2",
+    "protocolProfileBehavior": null,
+    "request": {
+     "auth": {
+      "apikey": null,
+      "awsv4": [
+       {
+        "key": "accessKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "secretKey",
+        "type": "string",
+        "value": "dummy"
+       },
+       {
+        "key": "region",
+        "type": "string",
+        "value": "us-east-1"
+       },
+       {
+        "key": "service",
+        "type": "string",
+        "value": "s3"
+       },
+       {
+        "key": "session_token",
+        "type": "string",
+        "value": null
+       }
+      ],
+      "basic": null,
+      "bearer": null,
+      "digest": null,
+      "edgegrid": null,
+      "hawk": null,
+      "noauth": null,
+      "ntlm": null,
+      "oauth1": null,
+      "oauth2": null,
+      "type": "awsv4"
+     },
+     "body": null,
+     "certificate": null,
+     "description": "fix region and service from url2",
+     "header": null,
+     "method": "GET",
+     "proxy": null,
+     "url": "http://s3.us-east-1.amazonaws.com/"
+    },
+    "response": null,
+    "variable": null,
+    "auth": null,
+    "item": null
+   }
+  ],
+  "protocolProfileBehavior": null,
+  "variable": null
+ }
 }

--- a/test/extensions/commands/http2postman/folderupload/examples.postman_collection.json
+++ b/test/extensions/commands/http2postman/folderupload/examples.postman_collection.json
@@ -1,1668 +1,1713 @@
 {
-  "collection": {
-    "auth": null,
+ "collection": {
+  "auth": null,
+  "event": null,
+  "info": {
+   "_postman_id": null,
+   "description": null,
+   "name": "examples",
+   "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+   "version": null
+  },
+  "item": [
+   {
+    "description": null,
     "event": null,
-    "info": {
-      "_postman_id": null,
-      "description": null,
-      "name": "examples",
-      "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-      "version": null
-    },
+    "id": null,
+    "name": "examples",
+    "protocolProfileBehavior": null,
+    "request": null,
+    "response": null,
+    "variable": null,
+    "auth": null,
     "item": [
-      {
+     {
+      "description": null,
+      "event": null,
+      "id": null,
+      "name": "auth",
+      "protocolProfileBehavior": null,
+      "request": null,
+      "response": null,
+      "variable": null,
+      "auth": null,
+      "item": [
+       {
         "description": null,
         "event": null,
         "id": null,
-        "name": "examples",
+        "name": "basic.http",
         "protocolProfileBehavior": null,
         "request": null,
         "response": null,
-        "variable": null,
+        "variable": [],
         "auth": null,
         "item": [
-          {
-            "description": null,
-            "event": null,
-            "id": null,
-            "name": "auth",
-            "protocolProfileBehavior": null,
-            "request": null,
-            "response": null,
-            "variable": null,
-            "auth": null,
-            "item": [
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "basic.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "basic auth",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": null,
-                        "basic": [
-                          {
-                            "key": "username",
-                            "type": "string",
-                            "value": "foo"
-                          },
-                          {
-                            "key": "password",
-                            "type": "string",
-                            "value": "bar"
-                          }
-                        ],
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "basic"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "basic auth",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://httpbin.org/basic-auth/foo/bar"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "digest.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "digest",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": null,
-                        "basic": null,
-                        "bearer": null,
-                        "digest": [
-                          {
-                            "key": "username",
-                            "type": "string",
-                            "value": "username"
-                          },
-                          {
-                            "key": "password",
-                            "type": "string",
-                            "value": "password"
-                          }
-                        ],
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "digest"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "digest",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "https://httpbin.org/digest-auth/20202/username/password/md5"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "description": null,
-            "event": null,
-            "id": null,
-            "name": "basic",
-            "protocolProfileBehavior": null,
-            "request": null,
-            "response": null,
-            "variable": null,
-            "auth": null,
-            "item": [
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "multidef.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "get",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": null,
-                      "certificate": null,
-                      "description": "get",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "https://httpbin.org/get"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "second",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": null,
-                      "certificate": null,
-                      "description": "second",
-                      "header": null,
-                      "method": "POST",
-                      "proxy": null,
-                      "url": "https://httpbin.org/post"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "urlparamsnheader.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "1",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": {
-                        "disabled": null,
-                        "file": null,
-                        "formdata": null,
-                        "graphql": null,
-                        "mode": "raw",
-                        "options": {
-                          "language": "json"
-                        },
-                        "raw": "{\"key\": \"value\"}",
-                        "urlencoded": null
-                      },
-                      "certificate": null,
-                      "description": "1",
-                      "header": [
-                        {
-                          "description": null,
-                          "disabled": false,
-                          "key": "content-type",
-                          "value": "application/json"
-                        },
-                        {
-                          "description": null,
-                          "disabled": false,
-                          "key": "content-type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "method": "POST",
-                      "proxy": null,
-                      "url": {
-                        "hash": null,
-                        "host": "httpbin.org",
-                        "path": "/post",
-                        "port": null,
-                        "protocol": "https",
-                        "query": [
-                          {
-                            "description": null,
-                            "disabled": false,
-                            "key": "key1",
-                            "value": "value2"
-                          },
-                          {
-                            "description": null,
-                            "disabled": false,
-                            "key": "key2",
-                            "value": "value2"
-                          },
-                          {
-                            "description": null,
-                            "disabled": false,
-                            "key": "key3",
-                            "value": "value2 with spaces"
-                          },
-                          {
-                            "description": null,
-                            "disabled": false,
-                            "key": "key4",
-                            "value": "value2 with single quotes"
-                          }
-                        ],
-                        "raw": "https://httpbin.org/post",
-                        "variable": null
-                      }
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "description": null,
-            "event": null,
-            "id": null,
-            "name": "misc",
-            "protocolProfileBehavior": null,
-            "request": null,
-            "response": null,
-            "variable": null,
-            "auth": null,
-            "item": [
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "awsauth.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "simple",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": [
-                          {
-                            "key": "accessKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "secretKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "region",
-                            "type": "string",
-                            "value": "us-east-1"
-                          },
-                          {
-                            "key": "service",
-                            "type": "string",
-                            "value": "s3"
-                          }
-                        ],
-                        "basic": null,
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "awsv4"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "simple",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://s3.amazonaws.com"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "resolve properties",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": [
-                          {
-                            "key": "accessKey",
-                            "type": "string",
-                            "value": "{{access_id}}"
-                          },
-                          {
-                            "key": "secretKey",
-                            "type": "string",
-                            "value": "{{secret_key}}"
-                          },
-                          {
-                            "key": "region",
-                            "type": "string",
-                            "value": "{{region}}"
-                          },
-                          {
-                            "key": "service",
-                            "type": "string",
-                            "value": "s3"
-                          }
-                        ],
-                        "basic": null,
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "awsv4"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "resolve properties",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://s3.amazonaws.com"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "extend3",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": [
-                          {
-                            "key": "accessKey",
-                            "type": "string",
-                            "value": "{{access_id}}"
-                          },
-                          {
-                            "key": "secretKey",
-                            "type": "string",
-                            "value": "{{secret_key}}"
-                          },
-                          {
-                            "key": "region",
-                            "type": "string",
-                            "value": "{{region}}"
-                          },
-                          {
-                            "key": "service",
-                            "type": "string",
-                            "value": "s3"
-                          }
-                        ],
-                        "basic": null,
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "awsv4"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "extend3",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://s3.amazonaws.com/some2"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "default us-east-1 region optional",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": [
-                          {
-                            "key": "accessKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "secretKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "region",
-                            "type": "string",
-                            "value": "us-east-1"
-                          },
-                          {
-                            "key": "service",
-                            "type": "string",
-                            "value": "s3"
-                          }
-                        ],
-                        "basic": null,
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "awsv4"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "default us-east-1 region optional",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://s3.amazonaws.com/some3"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "service from url and region defaulted to us-east-1",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": [
-                          {
-                            "key": "accessKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "secretKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "region",
-                            "type": "string",
-                            "value": "us-east-1"
-                          },
-                          {
-                            "key": "service",
-                            "type": "string",
-                            "value": "s3"
-                          }
-                        ],
-                        "basic": null,
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "awsv4"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "service from url and region defaulted to us-east-1",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://s3.amazonaws.com/"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "region and service from url with bucket id",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": [
-                          {
-                            "key": "accessKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "secretKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "region",
-                            "type": "string",
-                            "value": "us-east-1"
-                          },
-                          {
-                            "key": "service",
-                            "type": "string",
-                            "value": "s3"
-                          }
-                        ],
-                        "basic": null,
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "awsv4"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "region and service from url with bucket id",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://bucketid.s3.us-east-1.amazonaws.com/"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "region and service with legacy url",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": [
-                          {
-                            "key": "accessKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "secretKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "region",
-                            "type": "string",
-                            "value": "us-east-1"
-                          },
-                          {
-                            "key": "service",
-                            "type": "string",
-                            "value": "s3"
-                          }
-                        ],
-                        "basic": null,
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "awsv4"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "region and service with legacy url",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://s3-us-east-1.amazonaws.com/"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "fix region and service from url",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": [
-                          {
-                            "key": "accessKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "secretKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "region",
-                            "type": "string",
-                            "value": "us-east-1"
-                          },
-                          {
-                            "key": "service",
-                            "type": "string",
-                            "value": "s3"
-                          }
-                        ],
-                        "basic": null,
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "awsv4"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "fix region and service from url",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://s3-us-east-1.amazonaws.com/"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "fix region and service from url2",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": [
-                          {
-                            "key": "accessKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "secretKey",
-                            "type": "string",
-                            "value": "dummy"
-                          },
-                          {
-                            "key": "region",
-                            "type": "string",
-                            "value": "us-east-1"
-                          },
-                          {
-                            "key": "service",
-                            "type": "string",
-                            "value": "s3"
-                          }
-                        ],
-                        "basic": null,
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "awsv4"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "fix region and service from url2",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://s3.us-east-1.amazonaws.com/"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "extend.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "base",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": null,
-                        "basic": [
-                          {
-                            "key": "username",
-                            "type": "string",
-                            "value": "username"
-                          },
-                          {
-                            "key": "password",
-                            "type": "string",
-                            "value": "password"
-                          }
-                        ],
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "basic"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "base",
-                      "header": [
-                        {
-                          "description": null,
-                          "disabled": false,
-                          "key": "header1",
-                          "value": "headervalue1"
-                        }
-                      ],
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "https://httpbin.org/"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "sub",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": {
-                        "apikey": null,
-                        "awsv4": null,
-                        "basic": [
-                          {
-                            "key": "username",
-                            "type": "string",
-                            "value": "username"
-                          },
-                          {
-                            "key": "password",
-                            "type": "string",
-                            "value": "password"
-                          }
-                        ],
-                        "bearer": null,
-                        "digest": null,
-                        "edgegrid": null,
-                        "hawk": null,
-                        "noauth": null,
-                        "ntlm": null,
-                        "oauth1": null,
-                        "oauth2": null,
-                        "type": "basic"
-                      },
-                      "body": null,
-                      "certificate": null,
-                      "description": "sub",
-                      "header": [
-                        {
-                          "description": null,
-                          "disabled": false,
-                          "key": "header1",
-                          "value": "headervalue1"
-                        },
-                        {
-                          "description": null,
-                          "disabled": false,
-                          "key": "header2",
-                          "value": "headervalue2"
-                        }
-                      ],
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "https://httpbin.org/basic-auth/username/password"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "graphql.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "1",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": {
-                        "disabled": null,
-                        "file": null,
-                        "formdata": null,
-                        "graphql": null,
-                        "mode": "raw",
-                        "options": {
-                          "language": "json"
-                        },
-                        "raw": "{\"query\": \"{\\n          company {\\n            ceo\\n            coo\\n            cto_propulsion\\n            cto\\n            \\n            founded\\n            founder\\n            launch_sites\\n            name\\n            summary\\n            test_sites\\n            valuation\\n            vehicles\\n          }\\n        }\\n  \", \"variables\": null}",
-                        "urlencoded": null
-                      },
-                      "certificate": null,
-                      "description": "1",
-                      "header": [
-                        {
-                          "description": null,
-                          "disabled": false,
-                          "key": "content-type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "method": "POST",
-                      "proxy": null,
-                      "url": "https://api.spacex.land/graphql"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "script.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "text payload",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": null,
-                      "certificate": null,
-                      "description": "text payload",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http://httpbin.org/robots.txt"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "unix_socket.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "docker base",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": null,
-                      "certificate": null,
-                      "description": "docker base",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": "http+unix://%2Fvar%2Frun%2Fdocker.sock"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "varibles.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "1",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": null,
-                      "certificate": null,
-                      "description": "1",
-                      "header": null,
-                      "method": "GET",
-                      "proxy": null,
-                      "url": {
-                        "hash": null,
-                        "host": "httpbin.org",
-                        "path": "/{{var=get}}",
-                        "port": null,
-                        "protocol": "https",
-                        "query": [
-                          {
-                            "description": null,
-                            "disabled": false,
-                            "key": "path",
-                            "value": "{{var}}"
-                          }
-                        ],
-                        "raw": "https://httpbin.org/{{var=get}}",
-                        "variable": null
-                      }
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  },
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "2",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": {
-                        "disabled": null,
-                        "file": null,
-                        "formdata": null,
-                        "graphql": null,
-                        "mode": "raw",
-                        "options": {
-                          "language": "json"
-                        },
-                        "raw": "{\"firstname\": \"{{name=john}}\", \"lastname\": \"{{lastname=doe}}\", \"location\": \"hyderabad\", \"full name\": \"{{name}} {{lastname}}\"}",
-                        "urlencoded": null
-                      },
-                      "certificate": null,
-                      "description": "2",
-                      "header": [
-                        {
-                          "description": null,
-                          "disabled": false,
-                          "key": "content-type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "method": "POST",
-                      "proxy": null,
-                      "url": "https://httpbin.org/post"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "xmlpayload.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "xml payload",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": {
-                        "disabled": null,
-                        "file": null,
-                        "formdata": null,
-                        "graphql": null,
-                        "mode": "raw",
-                        "options": null,
-                        "raw": "\n<?xml version='1.0' encoding='us-ascii'?>\n\n<!--  A SAMPLE set of slides  -->\n\n<slideshow\n    title=\"Sample Slide Show\"\n    date=\"Date of publication\"\n    author=\"Yours Truly\"\n    >\n\n    <!-- TITLE SLIDE -->\n    <slide type=\"all\">\n        <title>Wake up to WonderWidgets!</title>\n    </slide>\n\n    <!-- OVERVIEW -->\n    <slide type=\"all\">\n        <title>Overview</title>\n        <item>Why <em>WonderWidgets</em> are great</item>\n        <item/>\n        <item>Who <em>buys</em> WonderWidgets</item>\n    </slide>\n\n</slideshow>\n",
-                        "urlencoded": null
-                      },
-                      "certificate": null,
-                      "description": "xml payload",
-                      "header": [
-                        {
-                          "description": null,
-                          "disabled": false,
-                          "key": "Content-Type",
-                          "value": "application/xml"
-                        }
-                      ],
-                      "method": "POST",
-                      "proxy": null,
-                      "url": "https://httpbin.org/post"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "description": null,
-            "event": null,
-            "id": null,
-            "name": "payload",
-            "protocolProfileBehavior": null,
-            "request": null,
-            "response": null,
-            "variable": null,
-            "auth": null,
-            "item": [
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "fileinput.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "1",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": {
-                        "disabled": null,
-                        "file": {
-                          "content": "",
-                          "src": "C:\\Users\\john\\documents\\movie.mkv"
-                        },
-                        "formdata": null,
-                        "graphql": null,
-                        "mode": "file",
-                        "options": null,
-                        "raw": null,
-                        "urlencoded": null
-                      },
-                      "certificate": null,
-                      "description": "1",
-                      "header": null,
-                      "method": "POST",
-                      "proxy": null,
-                      "url": "https://req.dothttp.dev"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "json.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "1",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": {
-                        "disabled": null,
-                        "file": null,
-                        "formdata": null,
-                        "graphql": null,
-                        "mode": "raw",
-                        "options": {
-                          "language": "json"
-                        },
-                        "raw": "{\"name\": \"john don\", \"age\": 20}",
-                        "urlencoded": null
-                      },
-                      "certificate": null,
-                      "description": "1",
-                      "header": [
-                        {
-                          "description": null,
-                          "disabled": false,
-                          "key": "content-type",
-                          "value": "application/json"
-                        }
-                      ],
-                      "method": "POST",
-                      "proxy": null,
-                      "url": "https://httpbin.org/post"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "multipart.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "1",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": {
-                        "disabled": null,
-                        "file": null,
-                        "formdata": [
-                          {
-                            "contentType": "text/plain",
-                            "description": null,
-                            "disabled": null,
-                            "key": "name",
-                            "type": "text",
-                            "value": "value",
-                            "src": null
-                          },
-                          {
-                            "contentType": "text/plain",
-                            "description": null,
-                            "disabled": null,
-                            "key": "name2",
-                            "type": "text",
-                            "value": "test.md",
-                            "src": null
-                          },
-                          {
-                            "contentType": "application/json",
-                            "description": null,
-                            "disabled": null,
-                            "key": "name3",
-                            "type": "text",
-                            "value": "{\"jsondata\" : \"jsonvalue\"}",
-                            "src": null
-                          }
-                        ],
-                        "graphql": null,
-                        "mode": "formdata",
-                        "options": null,
-                        "raw": null,
-                        "urlencoded": null
-                      },
-                      "certificate": null,
-                      "description": "1",
-                      "header": null,
-                      "method": "POST",
-                      "proxy": null,
-                      "url": "https://req.dothttp.dev"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "text.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "1",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": {
-                        "disabled": null,
-                        "file": null,
-                        "formdata": null,
-                        "graphql": null,
-                        "mode": "raw",
-                        "options": null,
-                        "raw": "this is text payload",
-                        "urlencoded": null
-                      },
-                      "certificate": null,
-                      "description": "1",
-                      "header": null,
-                      "method": "POST",
-                      "proxy": null,
-                      "url": {
-                        "hash": null,
-                        "host": "httpbin.org",
-                        "path": "/post",
-                        "port": null,
-                        "protocol": "https",
-                        "query": [
-                          {
-                            "description": null,
-                            "disabled": false,
-                            "key": "key1",
-                            "value": "value2"
-                          },
-                          {
-                            "description": null,
-                            "disabled": false,
-                            "key": "key2",
-                            "value": "value2"
-                          }
-                        ],
-                        "raw": "https://httpbin.org/post",
-                        "variable": null
-                      }
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              },
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "urlencode.http",
-                "protocolProfileBehavior": null,
-                "request": null,
-                "response": null,
-                "variable": [],
-                "auth": null,
-                "item": [
-                  {
-                    "description": null,
-                    "event": null,
-                    "id": null,
-                    "name": "1",
-                    "protocolProfileBehavior": null,
-                    "request": {
-                      "auth": null,
-                      "body": {
-                        "disabled": null,
-                        "file": null,
-                        "formdata": null,
-                        "graphql": null,
-                        "mode": "urlencoded",
-                        "options": null,
-                        "raw": null,
-                        "urlencoded": [
-                          {
-                            "description": null,
-                            "disabled": null,
-                            "key": "name",
-                            "value": "john"
-                          },
-                          {
-                            "description": null,
-                            "disabled": null,
-                            "key": "age",
-                            "value": 20
-                          },
-                          {
-                            "description": null,
-                            "disabled": null,
-                            "key": "lastname",
-                            "value": "doe"
-                          }
-                        ]
-                      },
-                      "certificate": null,
-                      "description": "1",
-                      "header": null,
-                      "method": "POST",
-                      "proxy": null,
-                      "url": "https://httpbin.org/post"
-                    },
-                    "response": null,
-                    "variable": null,
-                    "auth": null,
-                    "item": null
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "description": null,
-            "event": null,
-            "id": null,
-            "name": "example.http",
-            "protocolProfileBehavior": null,
-            "request": null,
-            "response": null,
-            "variable": [
-              {
-                "description": null,
-                "disabled": false,
-                "id": null,
-                "key": "username",
-                "name": null,
-                "system": null,
-                "type": null,
-                "value": "username"
-              },
-              {
-                "description": null,
-                "disabled": false,
-                "id": null,
-                "key": "password",
-                "name": null,
-                "system": null,
-                "type": null,
-                "value": "password"
-              },
-              {
-                "description": null,
-                "disabled": true,
-                "id": null,
-                "key": "x-requested-by",
-                "name": null,
-                "system": null,
-                "type": null,
-                "value": "dothttp"
-              },
-              {
-                "description": null,
-                "disabled": true,
-                "id": null,
-                "key": "name",
-                "name": null,
-                "system": null,
-                "type": null,
-                "value": "prasanth"
-              }
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "basic auth",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": null,
+            "basic": [
+             {
+              "key": "username",
+              "type": "string",
+              "value": "foo"
+             },
+             {
+              "key": "password",
+              "type": "string",
+              "value": "bar"
+             }
             ],
-            "auth": null,
-            "item": [
-              {
-                "description": null,
-                "event": null,
-                "id": null,
-                "name": "fetch 100 users, skip first 50",
-                "protocolProfileBehavior": null,
-                "request": {
-                  "auth": null,
-                  "body": {
-                    "disabled": null,
-                    "file": null,
-                    "formdata": null,
-                    "graphql": null,
-                    "mode": "raw",
-                    "options": null,
-                    "raw": "hai",
-                    "urlencoded": null
-                  },
-                  "certificate": null,
-                  "description": "fetch 100 users, skip first 50",
-                  "header": [
-                    {
-                      "description": null,
-                      "disabled": false,
-                      "key": "Authorization",
-                      "value": "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
-                    },
-                    {
-                      "description": null,
-                      "disabled": false,
-                      "key": "content-type",
-                      "value": "hai"
-                    }
-                  ],
-                  "method": "GET",
-                  "proxy": null,
-                  "url": {
-                    "hash": null,
-                    "host": "req.dothttp.dev",
-                    "path": "/user",
-                    "port": null,
-                    "protocol": "https",
-                    "query": [
-                      {
-                        "description": null,
-                        "disabled": false,
-                        "key": "fetch",
-                        "value": "100"
-                      },
-                      {
-                        "description": null,
-                        "disabled": false,
-                        "key": "skip",
-                        "value": "50"
-                      },
-                      {
-                        "description": null,
-                        "disabled": false,
-                        "key": "projection",
-                        "value": "name"
-                      },
-                      {
-                        "description": null,
-                        "disabled": false,
-                        "key": "projection",
-                        "value": "org"
-                      },
-                      {
-                        "description": null,
-                        "disabled": false,
-                        "key": "projection",
-                        "value": "location"
-                      }
-                    ],
-                    "raw": "https://req.dothttp.dev/user",
-                    "variable": null
-                  }
-                },
-                "response": null,
-                "variable": null,
-                "auth": null,
-                "item": null
-              }
-            ]
-          }
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "basic"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "basic auth",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://httpbin.org/basic-auth/foo/bar"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
         ]
-      }
-    ],
-    "protocolProfileBehavior": null,
-    "variable": null
-  }
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "digest.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "digest",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": null,
+            "basic": null,
+            "bearer": null,
+            "digest": [
+             {
+              "key": "username",
+              "type": "string",
+              "value": "username"
+             },
+             {
+              "key": "password",
+              "type": "string",
+              "value": "password"
+             }
+            ],
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "digest"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "digest",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "https://httpbin.org/digest-auth/20202/username/password/md5"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       }
+      ]
+     },
+     {
+      "description": null,
+      "event": null,
+      "id": null,
+      "name": "basic",
+      "protocolProfileBehavior": null,
+      "request": null,
+      "response": null,
+      "variable": null,
+      "auth": null,
+      "item": [
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "multidef.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "get",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": null,
+           "certificate": null,
+           "description": "get",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "https://httpbin.org/get"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "second",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": null,
+           "certificate": null,
+           "description": "second",
+           "header": null,
+           "method": "POST",
+           "proxy": null,
+           "url": "https://httpbin.org/post"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "urlparamsnheader.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "1",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": {
+            "disabled": null,
+            "file": null,
+            "formdata": null,
+            "graphql": null,
+            "mode": "raw",
+            "options": {
+             "language": "json"
+            },
+            "raw": "{\"key\": \"value\"}",
+            "urlencoded": null
+           },
+           "certificate": null,
+           "description": "1",
+           "header": [
+            {
+             "description": null,
+             "disabled": false,
+             "key": "content-type",
+             "value": "application/json"
+            },
+            {
+             "description": null,
+             "disabled": false,
+             "key": "content-type",
+             "value": "application/json"
+            }
+           ],
+           "method": "POST",
+           "proxy": null,
+           "url": {
+            "hash": null,
+            "host": "httpbin.org",
+            "path": "/post",
+            "port": null,
+            "protocol": "https",
+            "query": [
+             {
+              "description": null,
+              "disabled": false,
+              "key": "key1",
+              "value": "value2"
+             },
+             {
+              "description": null,
+              "disabled": false,
+              "key": "key2",
+              "value": "value2"
+             },
+             {
+              "description": null,
+              "disabled": false,
+              "key": "key3",
+              "value": "value2 with spaces"
+             },
+             {
+              "description": null,
+              "disabled": false,
+              "key": "key4",
+              "value": "value2 with single quotes"
+             }
+            ],
+            "raw": "https://httpbin.org/post",
+            "variable": null
+           }
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       }
+      ]
+     },
+     {
+      "description": null,
+      "event": null,
+      "id": null,
+      "name": "misc",
+      "protocolProfileBehavior": null,
+      "request": null,
+      "response": null,
+      "variable": null,
+      "auth": null,
+      "item": [
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "awsauth.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "simple",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": [
+             {
+              "key": "accessKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "secretKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "region",
+              "type": "string",
+              "value": "us-east-1"
+             },
+             {
+              "key": "service",
+              "type": "string",
+              "value": "s3"
+             },
+             {
+              "key": "session_token",
+              "type": "string",
+              "value": null
+             }
+            ],
+            "basic": null,
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "awsv4"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "simple",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://s3.amazonaws.com"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "resolve properties",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": [
+             {
+              "key": "accessKey",
+              "type": "string",
+              "value": "{{access_id}}"
+             },
+             {
+              "key": "secretKey",
+              "type": "string",
+              "value": "{{secret_key}}"
+             },
+             {
+              "key": "region",
+              "type": "string",
+              "value": "{{region}}"
+             },
+             {
+              "key": "service",
+              "type": "string",
+              "value": "s3"
+             },
+             {
+              "key": "session_token",
+              "type": "string",
+              "value": null
+             }
+            ],
+            "basic": null,
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "awsv4"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "resolve properties",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://s3.amazonaws.com"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "extend3",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": [
+             {
+              "key": "accessKey",
+              "type": "string",
+              "value": "{{access_id}}"
+             },
+             {
+              "key": "secretKey",
+              "type": "string",
+              "value": "{{secret_key}}"
+             },
+             {
+              "key": "region",
+              "type": "string",
+              "value": "{{region}}"
+             },
+             {
+              "key": "service",
+              "type": "string",
+              "value": "s3"
+             },
+             {
+              "key": "session_token",
+              "type": "string",
+              "value": null
+             }
+            ],
+            "basic": null,
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "awsv4"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "extend3",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://s3.amazonaws.com/some2"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "default us-east-1 region optional",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": [
+             {
+              "key": "accessKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "secretKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "region",
+              "type": "string",
+              "value": "us-east-1"
+             },
+             {
+              "key": "service",
+              "type": "string",
+              "value": "s3"
+             },
+             {
+              "key": "session_token",
+              "type": "string",
+              "value": null
+             }
+            ],
+            "basic": null,
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "awsv4"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "default us-east-1 region optional",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://s3.amazonaws.com/some3"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "service from url and region defaulted to us-east-1",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": [
+             {
+              "key": "accessKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "secretKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "region",
+              "type": "string",
+              "value": "us-east-1"
+             },
+             {
+              "key": "service",
+              "type": "string",
+              "value": "s3"
+             },
+             {
+              "key": "session_token",
+              "type": "string",
+              "value": null
+             }
+            ],
+            "basic": null,
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "awsv4"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "service from url and region defaulted to us-east-1",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://s3.amazonaws.com/"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "region and service from url with bucket id",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": [
+             {
+              "key": "accessKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "secretKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "region",
+              "type": "string",
+              "value": "us-east-1"
+             },
+             {
+              "key": "service",
+              "type": "string",
+              "value": "s3"
+             },
+             {
+              "key": "session_token",
+              "type": "string",
+              "value": null
+             }
+            ],
+            "basic": null,
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "awsv4"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "region and service from url with bucket id",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://bucketid.s3.us-east-1.amazonaws.com/"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "region and service with legacy url",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": [
+             {
+              "key": "accessKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "secretKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "region",
+              "type": "string",
+              "value": "us-east-1"
+             },
+             {
+              "key": "service",
+              "type": "string",
+              "value": "s3"
+             },
+             {
+              "key": "session_token",
+              "type": "string",
+              "value": null
+             }
+            ],
+            "basic": null,
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "awsv4"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "region and service with legacy url",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://s3-us-east-1.amazonaws.com/"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "fix region and service from url",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": [
+             {
+              "key": "accessKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "secretKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "region",
+              "type": "string",
+              "value": "us-east-1"
+             },
+             {
+              "key": "service",
+              "type": "string",
+              "value": "s3"
+             },
+             {
+              "key": "session_token",
+              "type": "string",
+              "value": null
+             }
+            ],
+            "basic": null,
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "awsv4"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "fix region and service from url",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://s3-us-east-1.amazonaws.com/"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "fix region and service from url2",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": [
+             {
+              "key": "accessKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "secretKey",
+              "type": "string",
+              "value": "dummy"
+             },
+             {
+              "key": "region",
+              "type": "string",
+              "value": "us-east-1"
+             },
+             {
+              "key": "service",
+              "type": "string",
+              "value": "s3"
+             },
+             {
+              "key": "session_token",
+              "type": "string",
+              "value": null
+             }
+            ],
+            "basic": null,
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "awsv4"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "fix region and service from url2",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://s3.us-east-1.amazonaws.com/"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "extend.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "base",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": null,
+            "basic": [
+             {
+              "key": "username",
+              "type": "string",
+              "value": "username"
+             },
+             {
+              "key": "password",
+              "type": "string",
+              "value": "password"
+             }
+            ],
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "basic"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "base",
+           "header": [
+            {
+             "description": null,
+             "disabled": false,
+             "key": "header1",
+             "value": "headervalue1"
+            }
+           ],
+           "method": "GET",
+           "proxy": null,
+           "url": "https://httpbin.org/"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "sub",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": {
+            "apikey": null,
+            "awsv4": null,
+            "basic": [
+             {
+              "key": "username",
+              "type": "string",
+              "value": "username"
+             },
+             {
+              "key": "password",
+              "type": "string",
+              "value": "password"
+             }
+            ],
+            "bearer": null,
+            "digest": null,
+            "edgegrid": null,
+            "hawk": null,
+            "noauth": null,
+            "ntlm": null,
+            "oauth1": null,
+            "oauth2": null,
+            "type": "basic"
+           },
+           "body": null,
+           "certificate": null,
+           "description": "sub",
+           "header": [
+            {
+             "description": null,
+             "disabled": false,
+             "key": "header1",
+             "value": "headervalue1"
+            },
+            {
+             "description": null,
+             "disabled": false,
+             "key": "header2",
+             "value": "headervalue2"
+            }
+           ],
+           "method": "GET",
+           "proxy": null,
+           "url": "https://httpbin.org/basic-auth/username/password"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "graphql.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "1",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": {
+            "disabled": null,
+            "file": null,
+            "formdata": null,
+            "graphql": null,
+            "mode": "raw",
+            "options": {
+             "language": "json"
+            },
+            "raw": "{\"query\": \"{\\n          company {\\n            ceo\\n            coo\\n            cto_propulsion\\n            cto\\n            \\n            founded\\n            founder\\n            launch_sites\\n            name\\n            summary\\n            test_sites\\n            valuation\\n            vehicles\\n          }\\n        }\\n  \", \"variables\": null}",
+            "urlencoded": null
+           },
+           "certificate": null,
+           "description": "1",
+           "header": [
+            {
+             "description": null,
+             "disabled": false,
+             "key": "content-type",
+             "value": "application/json"
+            }
+           ],
+           "method": "POST",
+           "proxy": null,
+           "url": "https://api.spacex.land/graphql"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "script.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "text payload",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": null,
+           "certificate": null,
+           "description": "text payload",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http://httpbin.org/robots.txt"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "unix_socket.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "docker base",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": null,
+           "certificate": null,
+           "description": "docker base",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": "http+unix://%2Fvar%2Frun%2Fdocker.sock"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "varibles.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "1",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": null,
+           "certificate": null,
+           "description": "1",
+           "header": null,
+           "method": "GET",
+           "proxy": null,
+           "url": {
+            "hash": null,
+            "host": "httpbin.org",
+            "path": "/{{var=get}}",
+            "port": null,
+            "protocol": "https",
+            "query": [
+             {
+              "description": null,
+              "disabled": false,
+              "key": "path",
+              "value": "{{var}}"
+             }
+            ],
+            "raw": "https://httpbin.org/{{var=get}}",
+            "variable": null
+           }
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         },
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "2",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": {
+            "disabled": null,
+            "file": null,
+            "formdata": null,
+            "graphql": null,
+            "mode": "raw",
+            "options": {
+             "language": "json"
+            },
+            "raw": "{\"firstname\": \"{{name=john}}\", \"lastname\": \"{{lastname=doe}}\", \"location\": \"hyderabad\", \"full name\": \"{{name}} {{lastname}}\"}",
+            "urlencoded": null
+           },
+           "certificate": null,
+           "description": "2",
+           "header": [
+            {
+             "description": null,
+             "disabled": false,
+             "key": "content-type",
+             "value": "application/json"
+            }
+           ],
+           "method": "POST",
+           "proxy": null,
+           "url": "https://httpbin.org/post"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "xmlpayload.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "xml payload",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": {
+            "disabled": null,
+            "file": null,
+            "formdata": null,
+            "graphql": null,
+            "mode": "raw",
+            "options": null,
+            "raw": "\n<?xml version='1.0' encoding='us-ascii'?>\n\n<!--  A SAMPLE set of slides  -->\n\n<slideshow\n    title=\"Sample Slide Show\"\n    date=\"Date of publication\"\n    author=\"Yours Truly\"\n    >\n\n    <!-- TITLE SLIDE -->\n    <slide type=\"all\">\n        <title>Wake up to WonderWidgets!</title>\n    </slide>\n\n    <!-- OVERVIEW -->\n    <slide type=\"all\">\n        <title>Overview</title>\n        <item>Why <em>WonderWidgets</em> are great</item>\n        <item/>\n        <item>Who <em>buys</em> WonderWidgets</item>\n    </slide>\n\n</slideshow>\n",
+            "urlencoded": null
+           },
+           "certificate": null,
+           "description": "xml payload",
+           "header": [
+            {
+             "description": null,
+             "disabled": false,
+             "key": "Content-Type",
+             "value": "application/xml"
+            }
+           ],
+           "method": "POST",
+           "proxy": null,
+           "url": "https://httpbin.org/post"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       }
+      ]
+     },
+     {
+      "description": null,
+      "event": null,
+      "id": null,
+      "name": "payload",
+      "protocolProfileBehavior": null,
+      "request": null,
+      "response": null,
+      "variable": null,
+      "auth": null,
+      "item": [
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "fileinput.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "1",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": {
+            "disabled": null,
+            "file": {
+             "content": "",
+             "src": "C:\\Users\\john\\documents\\movie.mkv"
+            },
+            "formdata": null,
+            "graphql": null,
+            "mode": "file",
+            "options": null,
+            "raw": null,
+            "urlencoded": null
+           },
+           "certificate": null,
+           "description": "1",
+           "header": null,
+           "method": "POST",
+           "proxy": null,
+           "url": "https://req.dothttp.dev"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "json.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "1",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": {
+            "disabled": null,
+            "file": null,
+            "formdata": null,
+            "graphql": null,
+            "mode": "raw",
+            "options": {
+             "language": "json"
+            },
+            "raw": "{\"name\": \"john don\", \"age\": 20}",
+            "urlencoded": null
+           },
+           "certificate": null,
+           "description": "1",
+           "header": [
+            {
+             "description": null,
+             "disabled": false,
+             "key": "content-type",
+             "value": "application/json"
+            }
+           ],
+           "method": "POST",
+           "proxy": null,
+           "url": "https://httpbin.org/post"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "multipart.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "1",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": {
+            "disabled": null,
+            "file": null,
+            "formdata": [
+             {
+              "contentType": "text/plain",
+              "description": null,
+              "disabled": null,
+              "key": "name",
+              "type": "text",
+              "value": "value",
+              "src": null
+             },
+             {
+              "contentType": "text/plain",
+              "description": null,
+              "disabled": null,
+              "key": "name2",
+              "type": "text",
+              "value": "test.md",
+              "src": null
+             },
+             {
+              "contentType": "application/json",
+              "description": null,
+              "disabled": null,
+              "key": "name3",
+              "type": "text",
+              "value": "{\"jsondata\" : \"jsonvalue\"}",
+              "src": null
+             }
+            ],
+            "graphql": null,
+            "mode": "formdata",
+            "options": null,
+            "raw": null,
+            "urlencoded": null
+           },
+           "certificate": null,
+           "description": "1",
+           "header": null,
+           "method": "POST",
+           "proxy": null,
+           "url": "https://req.dothttp.dev"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "text.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "1",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": {
+            "disabled": null,
+            "file": null,
+            "formdata": null,
+            "graphql": null,
+            "mode": "raw",
+            "options": null,
+            "raw": "this is text payload",
+            "urlencoded": null
+           },
+           "certificate": null,
+           "description": "1",
+           "header": null,
+           "method": "POST",
+           "proxy": null,
+           "url": {
+            "hash": null,
+            "host": "httpbin.org",
+            "path": "/post",
+            "port": null,
+            "protocol": "https",
+            "query": [
+             {
+              "description": null,
+              "disabled": false,
+              "key": "key1",
+              "value": "value2"
+             },
+             {
+              "description": null,
+              "disabled": false,
+              "key": "key2",
+              "value": "value2"
+             }
+            ],
+            "raw": "https://httpbin.org/post",
+            "variable": null
+           }
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       },
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "urlencode.http",
+        "protocolProfileBehavior": null,
+        "request": null,
+        "response": null,
+        "variable": [],
+        "auth": null,
+        "item": [
+         {
+          "description": null,
+          "event": null,
+          "id": null,
+          "name": "1",
+          "protocolProfileBehavior": null,
+          "request": {
+           "auth": null,
+           "body": {
+            "disabled": null,
+            "file": null,
+            "formdata": null,
+            "graphql": null,
+            "mode": "urlencoded",
+            "options": null,
+            "raw": null,
+            "urlencoded": [
+             {
+              "description": null,
+              "disabled": null,
+              "key": "name",
+              "value": "john"
+             },
+             {
+              "description": null,
+              "disabled": null,
+              "key": "age",
+              "value": 20
+             },
+             {
+              "description": null,
+              "disabled": null,
+              "key": "lastname",
+              "value": "doe"
+             }
+            ]
+           },
+           "certificate": null,
+           "description": "1",
+           "header": null,
+           "method": "POST",
+           "proxy": null,
+           "url": "https://httpbin.org/post"
+          },
+          "response": null,
+          "variable": null,
+          "auth": null,
+          "item": null
+         }
+        ]
+       }
+      ]
+     },
+     {
+      "description": null,
+      "event": null,
+      "id": null,
+      "name": "example.http",
+      "protocolProfileBehavior": null,
+      "request": null,
+      "response": null,
+      "variable": [
+       {
+        "description": null,
+        "disabled": false,
+        "id": null,
+        "key": "username",
+        "name": null,
+        "system": null,
+        "type": null,
+        "value": "username"
+       },
+       {
+        "description": null,
+        "disabled": false,
+        "id": null,
+        "key": "password",
+        "name": null,
+        "system": null,
+        "type": null,
+        "value": "password"
+       },
+       {
+        "description": null,
+        "disabled": true,
+        "id": null,
+        "key": "x-requested-by",
+        "name": null,
+        "system": null,
+        "type": null,
+        "value": "dothttp"
+       },
+       {
+        "description": null,
+        "disabled": true,
+        "id": null,
+        "key": "name",
+        "name": null,
+        "system": null,
+        "type": null,
+        "value": "prasanth"
+       }
+      ],
+      "auth": null,
+      "item": [
+       {
+        "description": null,
+        "event": null,
+        "id": null,
+        "name": "fetch 100 users, skip first 50",
+        "protocolProfileBehavior": null,
+        "request": {
+         "auth": null,
+         "body": {
+          "disabled": null,
+          "file": null,
+          "formdata": null,
+          "graphql": null,
+          "mode": "raw",
+          "options": null,
+          "raw": "hai",
+          "urlencoded": null
+         },
+         "certificate": null,
+         "description": "fetch 100 users, skip first 50",
+         "header": [
+          {
+           "description": null,
+           "disabled": false,
+           "key": "Authorization",
+           "value": "Basic dXNlcm5hbWU6cGFzc3dvcmQ="
+          },
+          {
+           "description": null,
+           "disabled": false,
+           "key": "content-type",
+           "value": "hai"
+          }
+         ],
+         "method": "GET",
+         "proxy": null,
+         "url": {
+          "hash": null,
+          "host": "req.dothttp.dev",
+          "path": "/user",
+          "port": null,
+          "protocol": "https",
+          "query": [
+           {
+            "description": null,
+            "disabled": false,
+            "key": "fetch",
+            "value": "100"
+           },
+           {
+            "description": null,
+            "disabled": false,
+            "key": "skip",
+            "value": "50"
+           },
+           {
+            "description": null,
+            "disabled": false,
+            "key": "projection",
+            "value": "name"
+           },
+           {
+            "description": null,
+            "disabled": false,
+            "key": "projection",
+            "value": "org"
+           },
+           {
+            "description": null,
+            "disabled": false,
+            "key": "projection",
+            "value": "location"
+           }
+          ],
+          "raw": "https://req.dothttp.dev/user",
+          "variable": null
+         }
+        },
+        "response": null,
+        "variable": null,
+        "auth": null,
+        "item": null
+       }
+      ]
+     }
+    ]
+   }
+  ],
+  "protocolProfileBehavior": null,
+  "variable": null
+ }
 }


### PR DESCRIPTION
Any new Feature should handle all of below

- http2har (export to all programming languages using httpsnippet or request sharing)
- har2http (swagger3 import, swagger2 import, curl import)
- postman2http (postman3 postman2 import)
- http2postman (export http file to postman request collection)
- http2curl (mirror, to check syntax or most scenarios)

are expected to work by default for any new feature. here is the checklist

- [x] check request executed properly
    - [x] test case
- [x] check har is generated properly and test case
    - [x] test case
- [x] check postman collection export of that use is generated properly
    - [x] test case
- [x] check with this new feature, postman import (few left out) can be bought back
    - [x] test case
- [x] check curl is generated like expected
    - [x] test case
- [x] check format is generated as expected
    - [x] test case