### PR TITLE
Update dependencies py310

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,9 +1,7 @@
 FROM python:3.11-slim
 
-# Install system dependencies (minimal set for faster builds)
+# Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    netcat-openbsd \
     libmagic1 \
     && rm -rf /var/lib/apt/lists/*
 
@@ -19,8 +17,9 @@ COPY pyproject.toml poetry.lock* ./
 # Configure poetry to not create virtual environments (we're in a container)
 RUN poetry config virtualenvs.create false
 
-# Install dependencies including dev dependencies (pytest, etc.)
+# Install dependencies including dev dependencies (pytest, gunicorn, httpbin, etc.)
 RUN poetry install --no-root
 
 # The actual code will be mounted as a volume at runtime
+# httpbin server is started automatically by pytest conftest.py fixture
 CMD ["poetry", "run", "pytest"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -371,7 +371,7 @@ description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
     {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
@@ -431,20 +431,19 @@ six = ">=1.10.0"
 
 [[package]]
 name = "flask"
-version = "3.1.2"
+version = "3.1.3"
 description = "A simple framework for building complex web applications."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "flask-3.1.2-py3-none-any.whl", hash = "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c"},
-    {file = "flask-3.1.2.tar.gz", hash = "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87"},
+    {file = "flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c"},
+    {file = "flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb"},
 ]
 
 [package.dependencies]
 blinker = ">=1.9.0"
 click = ">=8.1.3"
-importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
 itsdangerous = ">=2.2.0"
 jinja2 = ">=3.1.2"
 markupsafe = ">=2.1.1"
@@ -689,31 +688,6 @@ files = [
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.1"
-description = "Read metadata from Python packages"
-optional = false
-python-versions = ">=3.9"
-groups = ["main", "dev"]
-markers = "python_version == \"3.9\""
-files = [
-    {file = "importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"},
-    {file = "importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=3.4)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["mypy (<1.19) ; platform_python_implementation == \"PyPy\"", "pytest-mypy (>=1.0.1)"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -757,14 +731,14 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "jsonschema"
-version = "4.23.0"
+version = "4.25.1"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566"},
-    {file = "jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4"},
+    {file = "jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63"},
+    {file = "jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85"},
 ]
 
 [package.dependencies]
@@ -775,7 +749,7 @@ rpds-py = ">=0.7.1"
 
 [package.extras]
 format = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3987", "uri-template", "webcolors (>=1.11)"]
-format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "uri-template", "webcolors (>=24.6.0)"]
+format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-validator", "rfc3986-validator (>0.1.0)", "rfc3987-syntax (>=1.1.0)", "uri-template", "webcolors (>=24.6.0)"]
 
 [[package]]
 name = "jsonschema-specifications"
@@ -1525,7 +1499,6 @@ files = [
 
 [package.dependencies]
 Arpeggio = ">=2.0.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.10\""}
 
 [package.extras]
 cli = ["click (>=7.0,<9.0)"]
@@ -1551,7 +1524,7 @@ description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
     {file = "tomli-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:023aa114dd824ade0100497eb2318602af309e5a55595f76b626d6d9f3b7b0a6"},
@@ -1594,7 +1567,7 @@ description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
-markers = "python_version < \"3.11\""
+markers = "python_version == \"3.10\""
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -1679,28 +1652,7 @@ files = [
 [package.extras]
 test = ["pytest", "pytest-cov"]
 
-[[package]]
-name = "zipp"
-version = "3.23.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = false
-python-versions = ">=3.9"
-groups = ["main", "dev"]
-markers = "python_version == \"3.9\""
-files = [
-    {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
-    {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more_itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
-
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<3.15"
-content-hash = "53c77d4b1a5508040977eba5b6189ea156765fcb87b9ad0b4376900aba6ec72d"
+python-versions = ">=3.10,<3.15"
+content-hash = "3144cdc38f78703a380d1956e25e472898b74002cd9c4c0fa089d04affc03fb1"

--- a/poetry.lock
+++ b/poetry.lock
@@ -971,24 +971,25 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.9.0"
+version = "2.12.1"
 description = "JSON Web Token implementation in Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850"},
-    {file = "pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"},
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
 ]
 
 [package.dependencies]
 cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pyspnego"
@@ -1566,7 +1567,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "python_version == \"3.10\""
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
@@ -1621,18 +1622,18 @@ testing = ["coverage (>=7.6.0)", "pytest", "pytest-cov"]
 
 [[package]]
 name = "werkzeug"
-version = "3.1.3"
+version = "3.1.8"
 description = "The comprehensive WSGI web application library."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e"},
-    {file = "werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746"},
+    {file = "werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50"},
+    {file = "werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44"},
 ]
 
 [package.dependencies]
-MarkupSafe = ">=2.1.1"
+markupsafe = ">=2.1.1"
 
 [package.extras]
 watchdog = ["watchdog (>=2.3)"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dothttp-req"
-version = "0.0.44a29"
+version = "0.0.44a30"
 description = "Dothttp is Simple http client for testing and development"
 authors = ["Prasanth <kesavarapu.siva@gmail.com>"]
 license = "MIT"
@@ -21,8 +21,8 @@ dothttp = 'dothttp.__main__:main'
 
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.15"
-jsonschema = "4.23.0"
+python = ">=3.10,<3.15"
+jsonschema = "4.25.1"
 jstyleson = "0.0.2"
 textx = "4.2.3"
 requests-pkcs12 = "1.27"
@@ -40,10 +40,10 @@ xmltodict = "^1.0.2"
 
 [tool.poetry.group.dev.dependencies]
 waitress = "3.0.2"
-flask = "3.1.2"
+flask = "3.1.3"
 python-magic = "^0.4.27"
 flask-cors = "^6.0.1"
-pytest = "^8.3.5"
+pytest = "^8.4.2"
 pytest-html = "^4.1.1"
 pytest-xdist = "^3.6.1"
 gunicorn = "^23.0.0"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -8,74 +8,13 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Default values
-HTTPBIN_PORT=8000
-HTTPBIN_IMAGE="kennethreitz/httpbin"
-HTTPBIN_CONTAINER_NAME="dothttp-httpbin"
 TEST_IMAGE="dothttp-test-runner"
-CLEANUP_HTTPBIN=false
-
-# Function to check if a port is in use
-is_port_in_use() {
-    nc -z localhost "$1" 2>/dev/null
-}
-
-# Function to check if httpbin container is running
-is_httpbin_running() {
-    docker ps --filter "name=${HTTPBIN_CONTAINER_NAME}" --filter "status=running" --format "{{.Names}}" | grep -q "${HTTPBIN_CONTAINER_NAME}"
-}
-
-# Function to start httpbin
-start_httpbin() {
-    echo -e "${YELLOW}Starting httpbin container...${NC}"
-    docker run -d \
-        --name "${HTTPBIN_CONTAINER_NAME}" \
-        -p "${HTTPBIN_PORT}:80" \
-        "${HTTPBIN_IMAGE}" > /dev/null
-
-    echo -e "${GREEN}Waiting for httpbin to be ready...${NC}"
-    sleep 3
-
-    # Wait up to 30 seconds for httpbin to be ready
-    for i in {1..30}; do
-        if is_port_in_use "${HTTPBIN_PORT}"; then
-            echo -e "${GREEN}httpbin is ready on port ${HTTPBIN_PORT}${NC}"
-            return 0
-        fi
-        sleep 1
-    done
-
-    echo -e "${RED}httpbin failed to start${NC}"
-    return 1
-}
-
-# Function to stop httpbin
-stop_httpbin() {
-    if [ "${CLEANUP_HTTPBIN}" = true ]; then
-        echo -e "${YELLOW}Stopping httpbin container...${NC}"
-        docker stop "${HTTPBIN_CONTAINER_NAME}" > /dev/null 2>&1 || true
-        docker rm "${HTTPBIN_CONTAINER_NAME}" > /dev/null 2>&1 || true
-    fi
-}
 
 # Function to build test image
 build_test_image() {
     echo -e "${YELLOW}Building test runner image...${NC}"
     docker build -t "${TEST_IMAGE}" -f Dockerfile.test .
 }
-
-# Trap to ensure cleanup on exit
-trap stop_httpbin EXIT INT TERM
-
-# Check if httpbin is already running
-if is_httpbin_running; then
-    echo -e "${GREEN}httpbin container is already running${NC}"
-elif is_port_in_use "${HTTPBIN_PORT}"; then
-    echo -e "${GREEN}httpbin is already available on port ${HTTPBIN_PORT}${NC}"
-else
-    start_httpbin
-    CLEANUP_HTTPBIN=true
-fi
 
 # Build test image if it doesn't exist or if Dockerfile.test is newer
 if [ ! "$(docker images -q ${TEST_IMAGE} 2> /dev/null)" ] || [ Dockerfile.test -nt "$(docker inspect -f '{{.Created}}' ${TEST_IMAGE} 2>/dev/null || echo '1970-01-01')" ]; then
@@ -86,6 +25,7 @@ fi
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Run tests in docker container
+# httpbin server is started automatically by pytest conftest.py
 echo -e "${YELLOW}Running tests in Python 3.11 container...${NC}"
 docker run --rm \
     --network host \


### PR DESCRIPTION
Any new Feature should handle all of below

- http2har (export to all programming languages using httpsnippet or request sharing)
- har2http (swagger3 import, swagger2 import, curl import)
- postman2http (postman3 postman2 import)
- http2postman (export http file to postman request collection)
- http2curl (mirror, to check syntax or most scenarios)

are expected to work by default for any new feature. here is the checklist

- [ ] check request executed properly
    - [ ] test case
- [ ] check har is generated properly and test case
    - [ ] test case
- [ ] check postman collection export of that use is generated properly
    - [ ] test case
- [ ] check with this new feature, postman import (few left out) can be bought back
    - [ ] test case
- [ ] check curl is generated like expected
    - [ ] test case
- [ ] check format is generated as expected
    - [ ] test case