### PR TITLE
update to python3.13 and fix tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,8 +1,12 @@
-FROM python:3.11-slim
+FROM python:3.13-slim
 
-# Install system dependencies
+# Install system dependencies including build tools for compiling Python packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic1 \
+    gcc \
+    g++ \
+    make \
+    libffi-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install poetry

--- a/dothttp/utils/json_utils.py
+++ b/dothttp/utils/json_utils.py
@@ -79,6 +79,11 @@ class JSONEncoder(json.JSONEncoder):
 
             return text
 
+        # Convert indent to string if it's an integer (for Python 3.13+ compatibility)
+        indent = self.indent
+        if isinstance(indent, int):
+            indent = ' ' * indent
+
         if _one_shot and c_make_encoder is not None and self.indent is None:
             _iterencode = c_make_encoder(
                 markers,
@@ -96,7 +101,7 @@ class JSONEncoder(json.JSONEncoder):
                 markers,
                 self.default,
                 _encoder,
-                self.indent,
+                indent,
                 floatstr,
                 self.key_separator,
                 self.item_separator,

--- a/test/core/test_script_execution.py
+++ b/test/core/test_script_execution.py
@@ -97,7 +97,7 @@ class ScriptExecutionIntegration(TestCase):
             """
 class SampleTestCase(unittest.TestCase):
     def test_status_code(self):
-        self.assertEquals(200 , client.response.status_code)
+        self.assertEqual(200 , client.response.status_code)
 """
         )
 
@@ -140,18 +140,18 @@ def pre_request():
         props.add_command_line_property("ram", "raju")
         script_exe = ScriptExecutionPython(httpdef, props)
         script_exe.pre_request_script()
-        self.assertEquals({"ram": "ranga"}, httpdef.headers)
-        self.assertEquals({"new": "value", "ram": "raju"}, script_exe.client.properties)
+        self.assertEqual({"ram": "ranga"}, httpdef.headers)
+        self.assertEqual({"new": "value", "ram": "raju"}, script_exe.client.properties)
 
     def test_math_n_headers(self):
         resp = self.get_script_exe(
             """
 class SampleTestCase(unittest.TestCase):
     def test_math(self):
-        self.assertEquals(4 , math.pow(2,2))
+        self.assertEqual(4 , math.pow(2,2))
 
     def test_headers(self):
-        self.assertEquals("sample_value", client.response.headers.get("sample_header"))
+        self.assertEqual("sample_value", client.response.headers.get("sample_header"))
 
     def test_date(self):
         datetime.datetime.now()
@@ -159,7 +159,7 @@ class SampleTestCase(unittest.TestCase):
     def test_hash(self):
         hashobj = hashlib.sha512()
         hashobj.update(b'ram')
-        self.assertEquals("92f35115cca41c3270b11813164b0845108686761d73b3e6e4e95ae8380fbdd92c1b9d6ff0e6181214486e9eb7ccdd779ffe1b04b161e510c7d8e7da715eb0ae",
+        self.assertEqual("92f35115cca41c3270b11813164b0845108686761d73b3e6e4e95ae8380fbdd92c1b9d6ff0e6181214486e9eb7ccdd779ffe1b04b161e510c7d8e7da715eb0ae",
         hashobj.hexdigest())
 
 """
@@ -206,7 +206,7 @@ class SampleTestCase(unittest.TestCase):
             """
 class SampleTestCase(unittest.TestCase):
     def test_status_code(self):
-        self.assertEquals(401 , client.response.status_code)
+        self.assertEqual(401 , client.response.status_code)
 """
         )
         self.assertEqual(

--- a/test/core/test_substitution.py
+++ b/test/core/test_substitution.py
@@ -197,7 +197,7 @@ class SubstitutionTest(TestBase):
             file=f"{base_dir}/system_command.http", target="2"
         )
         request_data = json.loads(system_command_request.body)
-        self.assertEquals(request_data, {"sub": "world\n"}, "insecure flag is set")
+        self.assertEqual(request_data, {"sub": "world\n"}, "insecure flag is set")
 
 
         # test system command substitution as insecure flag is base
@@ -205,7 +205,7 @@ class SubstitutionTest(TestBase):
             file=f"{base_dir}/system_command.http", target="parent"
         )
         request_data = json.loads(system_command_request.body)
-        self.assertEquals(request_data, {"sub": "hello\n"}, "parent has insecure flag is set")
+        self.assertEqual(request_data, {"sub": "hello\n"}, "parent has insecure flag is set")
 
 
 
@@ -214,7 +214,7 @@ class SubstitutionTest(TestBase):
             file=f"{base_dir}/system_command.http", target="child"
         )
         request_data = json.loads(system_command_request.body)
-        self.assertEquals(request_data, {"sub": "hello\n"}, "grand parent has insecure flag is set")
+        self.assertEqual(request_data, {"sub": "hello\n"}, "grand parent has insecure flag is set")
 
 
     def test_substitution_from_env_variable(self):

--- a/test/extensions/test_commands.py
+++ b/test/extensions/test_commands.py
@@ -118,7 +118,7 @@ class ResovleTest(TestBase):
                 id=1,
             )
         )
-        self.assertEquals(
+        self.assertEqual(
             result.result["resolved"], "http://localhost:8000/get")
 
     def test_hover_url_content(self):
@@ -131,7 +131,7 @@ class ResovleTest(TestBase):
                     id=1,
                 )
             )
-            self.assertEquals(
+            self.assertEqual(
                 result.result["resolved"], "http://localhost:8000/get")
 
     def test_hover_json_content(self):
@@ -153,7 +153,7 @@ json({
             )
         )
         expected = {'totalSeconds': 10800}
-        self.assertEquals(expected, result.result["resolved"])
+        self.assertEqual(expected, result.result["resolved"])
 
         index2 = content.find("numOfHours * 60 * 60")
         result2 = resolve_handler.run(
@@ -163,7 +163,7 @@ json({
                 id=2,
             )
         )
-        self.assertEquals(10800, result2.result["resolved"])
+        self.assertEqual(10800, result2.result["resolved"])
 
     def test_hover_import_content(self):
         resolve_handler = GetHoveredResolvedParamContentHandler()
@@ -186,7 +186,7 @@ json({
             )
         )
         expected = "https://req.dothttp.dev/ram"
-        self.assertEquals(expected, result.result["resolved"])
+        self.assertEqual(expected, result.result["resolved"])
 
     def test_hover_context_content(self):
         resolve_handler = GetHoveredResolvedParamContentHandler()
@@ -212,7 +212,7 @@ GET "https://httpbin.org/get"
             )
         )
         expected = "https://httpbin.org/get/ram"
-        self.assertEquals(expected, result.result["resolved"])
+        self.assertEqual(expected, result.result["resolved"])
 
     def test_hover_context_with_no_target(self):
         resolve_handler = GetHoveredResolvedParamContentHandler()
@@ -245,7 +245,7 @@ GET "https://httpbin.org/get"
             )
         )
         expected = "https://httpbin.org/get/ranga"
-        self.assertEquals(expected, result.result["resolved"])
+        self.assertEqual(expected, result.result["resolved"])
 
         index = content.find("rama")
         result = resolve_handler.run(
@@ -257,7 +257,7 @@ GET "https://httpbin.org/get"
             )
         )
         expected = {"totalSeconds": 10800, "rama": "ranga"}
-        self.assertEquals(expected, result.result["resolved"])
+        self.assertEqual(expected, result.result["resolved"])
         
         # look for property name and resolve it
         
@@ -270,7 +270,7 @@ GET "https://httpbin.org/get"
                 id=1,
             )
         )
-        self.assertEquals({'name': 'numOfSeconds', 'value': 10800}, result.result["property_at_pos"])
+        self.assertEqual({'name': 'numOfSeconds', 'value': 10800}, result.result["property_at_pos"])
 
     def test_hover_import_relative_content(self):
         resolve_handler = GetHoveredResolvedParamContentHandler()
@@ -293,7 +293,7 @@ GET "https://httpbin.org/get"
             )
         )
         expected = "https://req.dothttp.dev/ram"
-        self.assertEquals(expected, result.result["resolved"])
+        self.assertEqual(expected, result.result["resolved"])
 
 
     def test_hover_query(self):
@@ -316,7 +316,7 @@ GET "https://httpbin.org/get"
             )
         )
         expected = "ram=ranga"
-        self.assertEquals(expected, result.result["resolved"])
+        self.assertEqual(expected, result.result["resolved"])
 
 
     def test_hover_headers(self):
@@ -339,7 +339,7 @@ GET "https://httpbin.org/get"
             )
         )
         expected = {'ram': 'ranga'}
-        self.assertEquals(expected, result.result["resolved"])
+        self.assertEqual(expected, result.result["resolved"])
 
 
 class FileExecute(TestBase):

--- a/test/extensions/test_content.py
+++ b/test/extensions/test_content.py
@@ -242,7 +242,7 @@ class FileExecute(TestBase):
             curl=False,
         )
         result.load_def()
-        self.assertEquals(result.httpdef.payload.json["a"], 10)
+        self.assertEqual(result.httpdef.payload.json["a"], 10)
         
         
     def test_from_context_with_var(self):
@@ -265,4 +265,4 @@ class FileExecute(TestBase):
             curl=False,
         )
         result.load_def()
-        self.assertEquals(result.httpdef.payload.json["a"], 12)
+        self.assertEqual(result.httpdef.payload.json["a"], 12)

--- a/test/extensions/test_http2postman.py
+++ b/test/extensions/test_http2postman.py
@@ -100,7 +100,7 @@ class Testhttp2postman(TestBase):
             return result.result
 
     def test_negative(self):
-        self.assertEquals(
+        self.assertEqual(
             {"error": True, "error_message": "filename not existent or invalid link"},
             self.error_scenario("ram.http"),
         )


### PR DESCRIPTION
Any new Feature should handle all of below

- http2har (export to all programming languages using httpsnippet or request sharing)
- har2http (swagger3 import, swagger2 import, curl import)
- postman2http (postman3 postman2 import)
- http2postman (export http file to postman request collection)
- http2curl (mirror, to check syntax or most scenarios)

are expected to work by default for any new feature. here is the checklist

- [ ] check request executed properly
    - [ ] test case
- [ ] check har is generated properly and test case
    - [ ] test case
- [ ] check postman collection export of that use is generated properly
    - [ ] test case
- [ ] check with this new feature, postman import (few left out) can be bought back
    - [ ] test case
- [ ] check curl is generated like expected
    - [ ] test case
- [ ] check format is generated as expected
    - [ ] test case