### PR TITLE
feat: include request headers in execute response (v0.0.44a33)

### DIFF
--- a/dotextensions/server/handlers/basic_handlers.py
+++ b/dotextensions/server/handlers/basic_handlers.py
@@ -181,6 +181,7 @@ class RunHttpFileHandler(BaseHandler):
         data = {}
         data.update(response_data["response"])  # deprecated
         data.update(response_data)
+        data["request_headers"] = dict(resp.request.headers)
         if not comp.args.no_cookie and "cookie" in resp.request.headers:
             # redirects can add cookies
             comp.httpdef.headers["cookie"] = resp.request.headers["cookie"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dothttp-req"
-version = "0.0.44a32"
+version = "0.0.44a33"
 description = "Dothttp is Simple http client for testing and development"
 authors = ["Prasanth <kesavarapu.siva@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- **`basic_handlers.py`**: In `get_request_result`, capture `dict(resp.request.headers)` and store it under the `request_headers` key in the result payload. This uses `requests.PreparedRequest.headers` so it reflects the exact headers sent on the wire — including headers added automatically by the `requests` library (e.g. `User-Agent`, `Accept-Encoding`, `Content-Length`) as well as any custom headers defined in the `.http` file.
- **`pyproject.toml`**: Bump version to `0.0.44a33`.

## Why

Previously the execute response only contained response headers (`resp.headers`). The VS Code notebook renderer (dothttp-runner) had no way to display what was actually sent in the request, making it harder to debug authentication issues, content-type mismatches, etc.

## Test plan

- [ ] Run a request with custom headers (e.g. `Authorization`, `X-Custom-Header`) and verify `request_headers` appears in the returned result dict
- [ ] Run a request with no custom headers and verify `request_headers` still appears (with default `requests` headers like `User-Agent`)
- [ ] Verify existing response fields (`headers`, `body`, `status`, etc.) are unaffected